### PR TITLE
Replace german by ngerman

### DIFF
--- a/ctext/ctext.cls
+++ b/ctext/ctext.cls
@@ -45,7 +45,7 @@
 \usepackage[left=2cm,right=2cm,top=2cm,bottom=2cm,includeheadfoot]{geometry}
 \let\footruleskip\undefined
 \usepackage[utf8]{inputenc}
-\usepackage[english,german]{babel}
+\usepackage[english,ngerman]{babel}
 \usepackage{titlesec,enumitem,graphicx,float,xifthen,translations,lmodern,csquotes,etoolbox,fancyhdr,kvoptions}
 \usepackage[linktocpage=true]{hyperref}
 \SetupKeyvalOptions{

--- a/etext/etext.cls
+++ b/etext/etext.cls
@@ -41,7 +41,7 @@
 \makeatletter
 \usepackage[left=2.5cm,right=2.5cm,top=2cm,bottom=2cm]{geometry}
 \RequirePackage[utf8]{inputenc}
-\RequirePackage[english,german]{babel}
+\RequirePackage[english,ngerman]{babel}
 \RequirePackage{titlesec,enumitem,graphicx,tocloft,float,ifthen,translations,csquotes,fancyhdr}
 \RequirePackage{mathpazo}
 \RequirePackage{helvet}

--- a/gtext/gtext.cls
+++ b/gtext/gtext.cls
@@ -47,7 +47,7 @@
 \usepackage[left=1.25cm,right=1.25cm,top=1.25cm,bottom=1.25cm,includeheadfoot]{geometry}
 \let\footruleskip\undefined
 \usepackage[utf8]{inputenc}
-\usepackage[english,german]{babel}
+\usepackage[english,ngerman]{babel}
 \newcommand{\headingstyle}[1]{\renewcommand{\@headingstyling}[#1]}
 \newcommand{\@headingstyling}{\rmfamily} %
 

--- a/htext/htext.cls
+++ b/htext/htext.cls
@@ -45,7 +45,7 @@
 \RequirePackage[left=2cm,right=2cm,top=2cm,bottom=2cm,includeheadfoot]{geometry}
 \let\footruleskip\undefined
 \RequirePackage[utf8]{inputenc}
-\RequirePackage[english,german]{babel}
+\RequirePackage[english,ngerman]{babel}
 \RequirePackage{xcolor,titlesec,enumitem,graphicx,float,xifthen,translations,csquotes,etoolbox,fancyhdr,kvoptions}
 \RequirePackage[linktocpage=true]{hyperref}
 \RequirePackage{mathpazo,helvet}

--- a/webtech/webtech.cls
+++ b/webtech/webtech.cls
@@ -39,7 +39,7 @@
 \usepackage[left=2cm,right=2cm,top=2cm,bottom=2cm,includeheadfoot]{geometry}
 \let\footruleskip\undefined
 \usepackage[utf8]{inputenc}
-\usepackage[english,german]{babel}
+\usepackage[english,ngerman]{babel}
 \usepackage{titlesec,enumitem,graphicx,float,xifthen,translations,lmodern,csquotes,etoolbox,fancyhdr,kvoptions,xcolor}
 \usepackage{avant}
 \usepackage{helvet}


### PR DESCRIPTION
For hyphenation according to »new« german orthography laws.

Signed-off-by: Adrian C. Hinrichs <adrian.hinrichs@rwth-aachen.de>